### PR TITLE
Make the icons lighter for the topbar buttons: menu, playlist-drawer,…

### DIFF
--- a/play-music.user.css
+++ b/play-music.user.css
@@ -41,6 +41,9 @@ body.qp #content-container.has-hero-image #material-app-bar #material-one-left .
 body.qp #content-container.has-hero-image.transparent #material-app-bar #material-one-left .music-logo-link { display: none; }
 .sj-search-box-1 { background-color: #383838; }
 body.qp #sliding-action-bar-container { background-color: #333; color: rgba(255, 255, 255, .7); }
+#topBar #gb#gb a.gb_D {background-position: 0px -138px; }
+#topBar iron-icon.paper-icon-button { color: #a3a3a3; }
+#topBar iron-icon.paper-icon-button:hover { color: #e0e0e0; }
 
 /* Search Box */
 .sj-search-box-0 { background: rgba(255, 255, 255, .15); }


### PR DESCRIPTION
The top bar icons were black for me (Firefox Dark theme), 
![top-bar_before-after](https://user-images.githubusercontent.com/448063/71202936-c3507680-22a5-11ea-8593-45dfcf1b000f.png)

here's how I fixed them:
- For the google apps icon I adjusted the background position to display a light icon
- For the left and right drawer toggles I set a color along with the hover color.

The color (and hover color) of the icons were color-picked off the google-apps image.

Thank you for this great theme!