### PR TITLE
Dark theme for the Music Manager download screen

### DIFF
--- a/play-music.user.css
+++ b/play-music.user.css
@@ -247,6 +247,8 @@ gpm-card-grid > [slot="title"] { color: white; }
 
 /* Settings */
 .nuq-view button.quiz-block .name{color: #5f5f5f}
+.upload-music-page.settings-card { background-color: #1a1a1a; color: #aaa; }
+.upload-music-page a.secondary { color: #fff; }
 
 /* Various fixes, like the f*cking Holo context menu on the Now Playing bar */
 .now-playing-menu.goog-menu, .goog-menu { border: none !important; border-radius: 2px; box-shadow: 0 1px 4px 0 rgba(0,0,0,0.37)!important; }


### PR DESCRIPTION
Since I was on the page I just quickly darkened it.
I'm unsure of the number of people that know of the Music Manager app.

The URL to the screen: [https://play.google.com/music/listen?u=0#/manager](https://play.google.com/music/listen?u=0#/manager)

Here's a preview: 
![music-manager-download_after](https://user-images.githubusercontent.com/448063/71447474-6cc8b980-2737-11ea-894a-1837ac716716.png)
